### PR TITLE
Added field for trustworthiness ranking

### DIFF
--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -8,7 +8,8 @@ CREATE TABLE url (
   domain varchar(255),
   crawler_rank integer,
   calculated integer,
-  last_read date
+  last_read date,
+  intrinsic_trustworthiness integer
 );
 CREATE TABLE link (
   src text NOT NULL REFERENCES url (url),


### PR DESCRIPTION
Added a field to `url` to store the intrinsic trust in a site. That way, we don't lose that information when we re-calculate the trustworthiness.